### PR TITLE
fix for unnamed request parameter

### DIFF
--- a/gce2retrofit/src/main/java/com/sqisland/gce2retrofit/Generator.java
+++ b/gce2retrofit/src/main/java/com/sqisland/gce2retrofit/Generator.java
@@ -292,7 +292,7 @@ public class Generator {
 
     if (method.request != null) {
       params.add("@Body " + method.request.$ref + " " +
-          method.request.parameterName);
+          (method.request.parameterName != null ? method.request.parameterName : "resource"));
     }
     for (Entry<String, JsonElement> param : getParams(method)) {
       params.add(param2String(param));

--- a/gce2retrofit/src/test/java/com/sqisland/gce2retrofit/GeneratorTest.java
+++ b/gce2retrofit/src/test/java/com/sqisland/gce2retrofit/GeneratorTest.java
@@ -78,6 +78,20 @@ public final class GeneratorTest {
     assertThat(factory.getCount()).isEqualTo(2);
   }
 
+  @Test
+  public void testNamelessParameter() throws IOException, URISyntaxException {
+    InputStreamReader reader = new InputStreamReader(
+        GeneratorTest.class.getResourceAsStream("/nameless-parameter/discovery.json"));
+    StringWriterFactory factory = new StringWriterFactory();
+    Generator.generate(reader, factory, null, EnumSet.allOf(Generator.MethodType.class));
+    
+    assertThat(factory.getString("com/appspot/nameless_parameter/model/TestObject.java"))
+        .isEqualTo(getExpectedString("/nameless-parameter/TestObject.java.model"));
+    assertThat(factory.getString("com/appspot/nameless_parameter/Nameless.java"))
+        .isEqualTo(getExpectedString("/nameless-parameter/Nameless.java.both"));
+    assertThat(factory.getCount()).isEqualTo(2);
+  }
+
   private void doTestHelloGreeting(EnumSet<Generator.MethodType> methodTypes, String suffix)
       throws IOException, URISyntaxException {
     InputStreamReader reader = new InputStreamReader(

--- a/gce2retrofit/src/test/resources/nameless-parameter/Nameless.java.both
+++ b/gce2retrofit/src/test/resources/nameless-parameter/Nameless.java.both
@@ -1,0 +1,23 @@
+package com.appspot.nameless_parameter;
+
+import com.appspot.nameless_parameter.model.*;
+
+import retrofit.Callback;
+import retrofit.http.Body;
+import retrofit.http.DELETE;
+import retrofit.http.GET;
+import retrofit.http.PATCH;
+import retrofit.http.POST;
+import retrofit.http.Path;
+import retrofit.http.Query;
+
+public interface Nameless {
+  @PATCH("/nameless/update")
+  TestObject patch(@Body TestObject resource);
+  @PATCH("/nameless/update")
+  void patch(@Body TestObject resource, Callback<TestObject> cb);
+  @POST("/nameless/update")
+  TestObject update(@Body TestObject resource);
+  @POST("/nameless/update")
+  void update(@Body TestObject resource, Callback<TestObject> cb);
+}

--- a/gce2retrofit/src/test/resources/nameless-parameter/TestObject.java.model
+++ b/gce2retrofit/src/test/resources/nameless-parameter/TestObject.java.model
@@ -1,0 +1,9 @@
+package com.appspot.nameless_parameter.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class TestObject {
+  public String message;
+}

--- a/gce2retrofit/src/test/resources/nameless-parameter/discovery.json
+++ b/gce2retrofit/src/test/resources/nameless-parameter/discovery.json
@@ -1,0 +1,51 @@
+{
+ "baseUrl": "https://nameless-parameter.appspot.com/_ah/api/helloworld/v1/",
+ "schemas": {
+  "TestObject": {
+   "id": "TestObject",
+   "type": "object",
+   "properties": {
+    "message": {
+     "type": "string"
+    }
+   }
+  }
+ },
+ "resources": {
+  "nameless": {
+   "methods": {
+    "patch": {
+     "id": "helloworld.nameless.patch",
+     "path": "nameless/update",
+     "httpMethod": "PATCH",
+     "description": "This method supports patch semantics.",
+     "request": {
+      "$ref": "TestObject"
+     },
+     "response": {
+      "$ref": "TestObject"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/userinfo.email"
+     ]
+    },
+    "update": {
+     "id": "helloworld.nameless.update",
+     "path": "nameless/update",
+     "httpMethod": "POST",
+     "description": "",
+     "request": {
+      "$ref": "TestObject",
+      "parameterName": "resource"
+     },
+     "response": {
+      "$ref": "TestObject"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/userinfo.email"
+     ]
+    }
+   }
+  }
+ }
+}


### PR DESCRIPTION
My discovery doc generates a 'patch' call which isn't directly specified in the api, for the following API method:

```
@endpoints.method(RPC_UpdateCollectionRequest, RPC_Collection, name='update', path='update')
```

I get these two entries in the discover doc:

```
"patch": {
 "id": "app.collection.patch",
 "path": "collection/update",
 "httpMethod": "PATCH",
 "description": "This method supports patch semantics.",
 "request": {
  "$ref": "EndpointCollectionRPCUpdateCollectionRequest"
 },
 "response": {
  "$ref": "EndpointModelRpcRPCCollection"
 },
 "scopes": [
  "https://www.googleapis.com/auth/userinfo.email"
 ]
},
```

and

```
"update": {
 "id": "app.collection.update",
 "path": "collection/update",
 "httpMethod": "POST",
 "description": "",
 "request": {
  "$ref": "EndpointCollectionRPCUpdateCollectionRequest",
  "parameterName": "resource"
 },
 "response": {
  "$ref": "EndpointModelRpcRPCCollection"
 },
 "scopes": [
  "https://www.googleapis.com/auth/userinfo.email"
 ]
}
```

As you can see, the generated patch call doesn't have a parameterName for the request, which results in the following generated retrofit methods:

```
@PATCH("/collection/update")
EndpointModelRpcRPCCollection patch(@Body EndpointCollectionRPCUpdateCollectionRequest null);
@PATCH("/collection/update")
void patch(@Body EndpointCollectionRPCUpdateCollectionRequest null, Callback<EndpointModelRpcRPCCollection> cb);
```

which doesn't compile because of the null statements.

The proposed solution has the disadvantage that if somebody has a param actually called request (and no parameterName for the body), it will conflict with the default value here. However, I think this is unlikely because this is most likely a bug in Google's discovery doc generating tool, which I will try to report.
