### PR TITLE
Added reactive java support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ e.g. https://2-dot-test-pont.appspot.com/_ah/api/discovery/v1/apis/helloworld/v1
 
 `methods.csv` (optional)
 
-Valid values are `sync` and `async`. If omitted, both synchronous and asynchronous
+Valid values are `sync`, `async` and `reactive`. If omitted, both synchronous and asynchronous
 interfaces will be generated.
 
 `classmap.tsv` (optional)

--- a/gce2retrofit/src/test/java/com/sqisland/gce2retrofit/GeneratorTest.java
+++ b/gce2retrofit/src/test/java/com/sqisland/gce2retrofit/GeneratorTest.java
@@ -17,6 +17,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(JUnit4.class)
 public final class GeneratorTest {
+  static final EnumSet<Generator.MethodType> BOTH_METHOD_TYPES = EnumSet.of(Generator.MethodType.SYNC, Generator.MethodType.ASYNC);
+
   @Test
   public void testHelloGreetingSync() throws IOException, URISyntaxException {
     doTestHelloGreeting(EnumSet.of(Generator.MethodType.SYNC), ".sync");
@@ -29,7 +31,12 @@ public final class GeneratorTest {
 
   @Test
   public void testHelloGreetingBoth() throws IOException, URISyntaxException {
-    doTestHelloGreeting(EnumSet.allOf(Generator.MethodType.class), ".both");
+    doTestHelloGreeting(BOTH_METHOD_TYPES, ".both");
+  }
+
+  @Test
+  public void testHelloGreetingReactive() throws IOException, URISyntaxException {
+    doTestHelloGreeting(EnumSet.of(Generator.MethodType.REACTIVE), ".reactive");
   }
 
   @Test
@@ -69,7 +76,7 @@ public final class GeneratorTest {
     InputStreamReader reader = new InputStreamReader(
         GeneratorTest.class.getResourceAsStream("/nested-resources/discovery.json"));
     StringWriterFactory factory = new StringWriterFactory();
-    Generator.generate(reader, factory, null, EnumSet.allOf(Generator.MethodType.class));
+    Generator.generate(reader, factory, null, BOTH_METHOD_TYPES);
     
     assertThat(factory.getString("com/appspot/nested_resources/model/TestObject.java"))
         .isEqualTo(getExpectedString("/nested-resources/TestObject.java.model"));
@@ -83,7 +90,7 @@ public final class GeneratorTest {
     InputStreamReader reader = new InputStreamReader(
         GeneratorTest.class.getResourceAsStream("/nameless-parameter/discovery.json"));
     StringWriterFactory factory = new StringWriterFactory();
-    Generator.generate(reader, factory, null, EnumSet.allOf(Generator.MethodType.class));
+    Generator.generate(reader, factory, null, BOTH_METHOD_TYPES);
     
     assertThat(factory.getString("com/appspot/nameless_parameter/model/TestObject.java"))
         .isEqualTo(getExpectedString("/nameless-parameter/TestObject.java.model"));

--- a/gce2retrofit/src/test/resources/helloworld/Greetings.java.reactive
+++ b/gce2retrofit/src/test/resources/helloworld/Greetings.java.reactive
@@ -1,0 +1,24 @@
+package com.appspot.example;
+
+import com.appspot.example.model.*;
+
+import retrofit.Callback;
+import retrofit.http.Body;
+import retrofit.http.DELETE;
+import retrofit.http.GET;
+import retrofit.http.PATCH;
+import retrofit.http.POST;
+import retrofit.http.Path;
+import retrofit.http.Query;
+import rx.Observable;
+
+public interface Greetings {
+  @POST("/hellogreeting/authed")
+  Observable<HelloGreeting> authedRx();
+  @GET("/hellogreeting/{id}")
+  Observable<HelloGreeting> getGreetingRx(@Path("id") int id);
+  @GET("/hellogreeting")
+  Observable<HelloGreetingCollection> listGreetingRx();
+  @POST("/hellogreeting/{times}")
+  Observable<HelloGreeting> multiplyRx(@Body HelloGreeting resource, @Path("times") int times);
+}


### PR DESCRIPTION
I've added a new methods clause - reactive to get Observable returns. 

The changes mean there are 3 possible parameters for methods.csv - sync, async & reactive. The default - both - will still return just sync & async. 

For simplicity, I have appended RX to the method name to avoid name conflicts with the sync methods.
