### PR TITLE
Migrate Room and Annotations to AndroidX

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Apply the plugin in your `build.gradle`:
         }
       }
       dependencies {
-        classpath 'com.sqisland:gce2retrofit:1.5.0-SNAPSHOT'
+        classpath 'com.sqisland:gce2retrofit:2.0.0-SNAPSHOT'
       }
     }
 
@@ -77,14 +77,17 @@ Apply the plugin in your `build.gradle`:
 
 ## Upgrade guide
 
+### Version 2.0.0
+Migrate your project to [AndroidX](https://developer.android.com/jetpack/androidx/migrate)
+
+### Version 1.6.0
+Room.json file has been updated so each type(class/field) takes a list of annotations.
+
 ### Version 1.1.0
 
 Primitives have been replaced by Objects e.g. `Integer` instead of `int`. Please go through your
 code and make sure that you check for `null` before using the value of any `Boolean`, `Integer`,
 `Float` and `Double`.
-
-### Version 1.6.0
-Room.json file has been updated so each type(class/field) takes a list of annotations.
 
 ## Contributing
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
   repositories {
     jcenter()
+    google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.0'
+    classpath 'com.android.tools.build:gradle:3.3.0'
 
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files
@@ -15,5 +16,6 @@ buildscript {
 allprojects {
   repositories {
     jcenter()
+    google()
   }
 }

--- a/gce2retrofit/build.gradle
+++ b/gce2retrofit/build.gradle
@@ -48,7 +48,7 @@ jar {
 apply plugin: 'maven'
 
 group = 'com.sqisland'
-version = '1.6.0-SNAPSHOT'
+version = '2.0.0-SNAPSHOT'
 
 install {
   repositories {

--- a/gce2retrofit/build.gradle
+++ b/gce2retrofit/build.gradle
@@ -21,19 +21,19 @@ repositories {
 }
 
 dependencies {
-  compile gradleApi()
-  compile localGroovy()
+  implementation gradleApi()
+  implementation localGroovy()
 
-  compile 'com.android.tools.build:gradle:2.1.0'
+  implementation 'com.android.tools.build:gradle:2.1.0'
 
-  compile 'com.squareup.retrofit:retrofit:1.9.0'
-  compile 'com.google.code.gson:gson:2.4'
-  compile 'com.squareup:javawriter:2.5.1'
-  compile 'org.apache.commons:commons-lang3:3.3.2'
-  compile 'commons-cli:commons-cli:1.2'
+  implementation 'com.squareup.retrofit:retrofit:1.9.0'
+  implementation 'com.google.code.gson:gson:2.4'
+  implementation 'com.squareup:javawriter:2.5.1'
+  implementation 'org.apache.commons:commons-lang3:3.3.2'
+  implementation 'commons-cli:commons-cli:1.2'
 
-  testCompile 'junit:junit:4.12'
-  testCompile 'com.google.truth:truth:0.25'
+  testImplementation 'junit:junit:4.12'
+  testImplementation 'com.google.truth:truth:0.25'
 }
 
 jar {

--- a/gce2retrofit/src/main/java/com/sqisland/gce2retrofit/Generator.java
+++ b/gce2retrofit/src/main/java/com/sqisland/gce2retrofit/Generator.java
@@ -46,18 +46,18 @@ public class Generator {
 
   private static final List<String> roomImports = new ArrayList<String>() {
     {
-      add("android.arch.persistence.room.ColumnInfo");
-      add("android.arch.persistence.room.ColumnInfo.Collate");
-      add("android.arch.persistence.room.ColumnInfo.SQLiteTypeAffinity");
-      add("android.arch.persistence.room.Embedded");
-      add("android.arch.persistence.room.Entity");
-      add("android.arch.persistence.room.ForeignKey");
-      add("android.arch.persistence.room.ForeignKey.Action");
-      add("android.arch.persistence.room.Ignore");
-      add("android.arch.persistence.room.Index");
-      add("android.arch.persistence.room.PrimaryKey");
-      add("android.arch.persistence.room.Relation");
-      add("android.support.annotation.NonNull");
+      add("androidx.room.ColumnInfo");
+      add("androidx.room.ColumnInfo.Collate");
+      add("androidx.room.ColumnInfo.SQLiteTypeAffinity");
+      add("androidx.room.Embedded");
+      add("androidx.room.Entity");
+      add("androidx.room.ForeignKey");
+      add("androidx.room.ForeignKey.Action");
+      add("androidx.room.Ignore");
+      add("androidx.room.Index");
+      add("androidx.room.PrimaryKey");
+      add("androidx.room.Relation");
+      add("androidx.annotation.NonNull");
     }
   };
 

--- a/gce2retrofit/src/test/resources/room/HelloGreeting.java.model
+++ b/gce2retrofit/src/test/resources/room/HelloGreeting.java.model
@@ -1,17 +1,17 @@
 package com.appspot.example.model;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.ColumnInfo.Collate;
-import android.arch.persistence.room.ColumnInfo.SQLiteTypeAffinity;
-import android.arch.persistence.room.Embedded;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.ForeignKey;
-import android.arch.persistence.room.ForeignKey.Action;
-import android.arch.persistence.room.Ignore;
-import android.arch.persistence.room.Index;
-import android.arch.persistence.room.PrimaryKey;
-import android.arch.persistence.room.Relation;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
+import androidx.room.ColumnInfo;
+import androidx.room.ColumnInfo.Collate;
+import androidx.room.ColumnInfo.SQLiteTypeAffinity;
+import androidx.room.Embedded;
+import androidx.room.Entity;
+import androidx.room.ForeignKey;
+import androidx.room.ForeignKey.Action;
+import androidx.room.Ignore;
+import androidx.room.Index;
+import androidx.room.PrimaryKey;
+import androidx.room.Relation;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-all.zip

--- a/sample-android/build.gradle
+++ b/sample-android/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 27
-  buildToolsVersion '27.0.1'
+  compileSdkVersion 28
+  buildToolsVersion '28.0.3'
 
   defaultConfig {
     applicationId 'com.sqisland.gce2retrofit'
     minSdkVersion 10
-    targetSdkVersion 27
+    targetSdkVersion 28
     versionCode 1
     versionName '1.0.0'
   }
@@ -21,9 +21,9 @@ android {
 }
 
 dependencies {
-  compile fileTree(dir: 'libs', include: ['*.jar'])
-  compile 'com.squareup.retrofit2:retrofit:2.3.0'
-  compile 'com.squareup.retrofit2:converter-gson:2.3.0'
+  implementation fileTree(dir: 'libs', include: ['*.jar'])
+  implementation 'com.squareup.retrofit2:retrofit:2.3.0'
+  implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
 }
 
 buildscript {

--- a/sample-android/build.gradle
+++ b/sample-android/build.gradle
@@ -42,7 +42,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.sqisland:gce2retrofit:1.6.0-SNAPSHOT'
+    classpath 'com.sqisland:gce2retrofit:2.0.0-SNAPSHOT'
   }
 }
 

--- a/sample-java/build.gradle
+++ b/sample-java/build.gradle
@@ -23,7 +23,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.sqisland:gce2retrofit:1.6.0-SNAPSHOT'
+    classpath 'com.sqisland:gce2retrofit:2.0.0-SNAPSHOT'
   }
 }
 

--- a/sample-java/build.gradle
+++ b/sample-java/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'application'
 mainClassName = 'com.sqisland.gce2retrofit.discovery.Discovery'
 
 dependencies {
-  compile 'com.squareup.retrofit2:retrofit:2.0.2'
-  compile 'com.squareup.retrofit2:converter-gson:2.0.2'
+  implementation 'com.squareup.retrofit2:retrofit:2.0.2'
+  implementation 'com.squareup.retrofit2:converter-gson:2.0.2'
 }
 
 buildscript {


### PR DESCRIPTION
## What's new?
* Bump version to 2.0.0-SNAPSHOT
* Update gradle-wrapper and gradle plugin versions
* Using AndroidX packages for generated code.
  * `android.arch.persistence.room` -> `androidx.room`
  * `android.support.annotation` -> `androidx.annotation`